### PR TITLE
Uninstall lru_cache and install sin_lru_redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ The `tailwind_merge` config is an object with several keys:
 tailwind_merge_config = {
   # ↓ *Optional* Define how many values should be stored in cache.
   cache_size: 500,
+  # ↓ *Optional* Enable or disable caching nil values.
+  ignore_empty_cache: true,
   # ↓ *Optional* modifier separator from Tailwind config
   separator: ":",
   # ↓ *Optional* prefix from Tailwind config

--- a/lib/tailwind_merge.rb
+++ b/lib/tailwind_merge.rb
@@ -26,7 +26,7 @@ module TailwindMerge
       end
 
       @class_utils = TailwindMerge::ClassUtils.new(@config)
-      @cache = LruRedux::Cache.new(@config[:cache_size])
+      @cache = LruRedux::Cache.new(@config[:cache_size], @config[:ignore_empty_cache])
     end
 
     def merge(classes)

--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -84,6 +84,7 @@ module TailwindMerge
 
     DEFAULTS = {
       cache_size: 500,
+      ignore_empty_cache: true,
       separator: ":",
       theme: {
         "colors" => [IS_ANY],

--- a/lib/tailwind_merge/version.rb
+++ b/lib/tailwind_merge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TailwindMerge
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end

--- a/tailwind_merge.gemspec
+++ b/tailwind_merge.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("lru_redux", "~> 1.1")
+  spec.add_dependency("sin_lru_redux")
 
   spec.add_development_dependency("minitest", "~> 5.6")
   spec.add_development_dependency("minitest-focus", "~> 1.1")

--- a/tailwind_merge.gemspec
+++ b/tailwind_merge.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("sin_lru_redux")
+  spec.add_dependency("sin_lru_redux", "~> 2.5")
 
   spec.add_development_dependency("minitest", "~> 5.6")
   spec.add_development_dependency("minitest-focus", "~> 1.1")

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -7,6 +7,7 @@ class TestConfig < Minitest::Test
     config = TailwindMerge::Config::DEFAULTS
 
     assert_equal(500, config[:cache_size])
+    assert(config[:ignore_empty_cache])
     refute(config[:nonexistent])
     assert_equal("block", config[:class_groups]["display"].first)
     assert_equal("auto", config[:class_groups]["overflow"].first["overflow"].first)


### PR DESCRIPTION
### What's changed

- Uninstall lru_redux and install sin_lru_redux because lru_redux has not been maintained for over 10 years
- Add ignore_empty_cache option for saving memory
