### PR TITLE
Fix memory leak when passing `:theme` in config

### DIFF
--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -2444,18 +2444,32 @@ module TailwindMerge
     }.freeze
 
     def merge_config(incoming_config)
-      extended_config = TailwindMerge::Config::DEFAULTS.dup
+      extended_config = duplicate_config_value(TailwindMerge::Config::DEFAULTS)
 
-      incoming_theme = incoming_config.delete(:theme) || {}
+      incoming_theme = incoming_config.fetch(:theme, nil) || {}
       # if the incoming config has a theme, we...
       incoming_theme.each_pair do |key, scales|
         # ...add new scales to the existing ones
+        extended_config[:theme][key] ||= []
         extended_config[:theme][key] << ->(klass) {
           scales.include?(klass)
         }
       end
 
-      extended_config.merge(incoming_config)
+      extended_config.merge(incoming_config.reject { |key, _| key == :theme })
+    end
+
+    private def duplicate_config_value(value)
+      case value
+      when Hash
+        value.each_with_object({}) do |(key, child_value), copy|
+          copy[key] = duplicate_config_value(child_value)
+        end
+      when Array
+        value.map { |child_value| duplicate_config_value(child_value) }
+      else
+        value
+      end
     end
   end
 end

--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -2445,13 +2445,13 @@ module TailwindMerge
 
     def merge_config(incoming_config)
       extended_config = TailwindMerge::Config::DEFAULTS.dup
-      extended_config[:theme] = TailwindMerge::Config::DEFAULTS[:theme].transform_values(&:dup)
+      extended_config[:theme] = TailwindMerge::Config::DEFAULTS[:theme].dup
 
       incoming_theme = incoming_config.fetch(:theme, nil) || {}
       # if the incoming config has a theme, we...
       incoming_theme.each_pair do |key, scales|
         # ...add new scales to the existing ones
-        extended_config[:theme][key] ||= []
+        extended_config[:theme][key] = extended_config[:theme][key].dup
         extended_config[:theme][key] << ->(klass) {
           scales.include?(klass)
         }

--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -2444,7 +2444,8 @@ module TailwindMerge
     }.freeze
 
     def merge_config(incoming_config)
-      extended_config = duplicate_config_value(TailwindMerge::Config::DEFAULTS)
+      extended_config = TailwindMerge::Config::DEFAULTS.dup
+      extended_config[:theme] = TailwindMerge::Config::DEFAULTS[:theme].transform_values(&:dup)
 
       incoming_theme = incoming_config.fetch(:theme, nil) || {}
       # if the incoming config has a theme, we...
@@ -2457,19 +2458,6 @@ module TailwindMerge
       end
 
       extended_config.merge(incoming_config.reject { |key, _| key == :theme })
-    end
-
-    private def duplicate_config_value(value)
-      case value
-      when Hash
-        value.each_with_object({}) do |(key, child_value), copy|
-          copy[key] = duplicate_config_value(child_value)
-        end
-      when Array
-        value.map { |child_value| duplicate_config_value(child_value) }
-      else
-        value
-      end
     end
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -13,4 +13,29 @@ class TestConfig < Minitest::Test
     assert_equal("auto", config[:class_groups]["overflow"].first["overflow"].first)
     refute(config[:class_groups]["overflow"].first[:nonexistent])
   end
+
+  def test_custom_theme_does_not_mutate_default_config
+    default_spacing = TailwindMerge::Config::DEFAULTS[:theme]["spacing"].dup
+
+    3.times do |index|
+      TailwindMerge::Merger.new(config: { theme: { "spacing" => ["custom-spacing-#{index}"] } })
+    end
+
+    assert_equal(default_spacing, TailwindMerge::Config::DEFAULTS[:theme]["spacing"])
+  end
+
+  def test_merge_config_does_not_mutate_incoming_config
+    config = {
+      cache_size: 10,
+      theme: {
+        "spacing" => ["custom-spacing"],
+      },
+    }
+    original_config = config.dup
+    original_config[:theme] = config[:theme].dup
+
+    TailwindMerge::Merger.new(config:)
+
+    assert_equal(original_config, config)
+  end
 end


### PR DESCRIPTION
We recently discovered a memory leak in the `TailwindMerge::Config#merge_config` method that occurs every time you construct a `Merger` with a custom configuration. When the configuration is duplicated from the default, it's not a deep duplicate, so for example the entries in the `:theme` key are still references to entries in the the global `TailwindMerge::Config::DEFAULTS` hash. But if the `incoming_config` includes `:theme` entries, `merge_config` ends up extending the theme keys with a validator lambda, and since it's not a deep duplicate, that ends up modifying the global `DEFAULTS` hash which is unexpected because it is a [frozen constant](https://github.com/volition-co/tailwind_merge/blob/f3ce26193a33ac8fab3fdc3ad47a2e0d82589159/lib/tailwind_merge/config.rb#L2444). That also means that each time you construct a new `Merger`, even if it has the same configuration, a new validator is added onto the DEFAULTS entry for that theme key, so the time needed to validate goes up linearly with the number of times you've constructed a `TailwindMerge::Merger` object.

On the memory side of things, because the validator is a lambda, it actually holds a reference to `self` inside that function. Thus, each time you create a new `Tailwind::Merger` object with custom theme keys set, the global DEFAULTS hash holds a new reference to the newly created `Tailwind::Merger` object, so they can never be GC'ed.

The fix proposed here takes care to duplicate the theme keys before modifying their validator arrays. This way, the global DEFAULT is not modified and we don't append validators or hold onto object references past their natural lifespan.

In our application, we were creating a single memoized `Tailwind::Merger` object on each request, but because of this lambda reference, each request would increase the memory retained by a substantial amount, leading to eventual OOM and application restart. After fixing this issue memory usage plateaued at a pretty reasonable amount.

<img width="2698" height="964" alt="image" src="https://github.com/user-attachments/assets/4c3f8438-8560-48d4-a55a-c4b2d3630be5" />

Full disclosure: We found this bug by tasking coding agents to run our Rails app under https://github.com/zombocom/derailed_benchmarks and find sources of memory bloat or leaks. After getting the same results from multiple agents we analyzed the code ourselves to confirm that the findings were real and deployed the fix to a staging environment to verify and measure the impact of the change. After deploying this change we found that our memory leak issue went away. We also observed that the upward trend of response times over the lifespan of a server process was resolved - this makes sense because of the linearly increasing cost of validators.

Codex also generated this helpful benchmark script you can use to see the impact of the leak.

https://gist.github.com/ibrahima/a507c97838b1fbe41c5d45ed8ce07cdf

Screencast of the script run on `main`: note that it takes a while to get to 1000 iterations, and the total memory usage of the process goes up to ~6.5GB

https://github.com/user-attachments/assets/277d711f-9260-4c35-8e38-ca5264d9faed

On the fixed branch: script runs fast, uses negligible memory.

https://github.com/user-attachments/assets/861231d6-56d9-44a2-b6b6-323791512bfa

Thank you for taking the time to look at this!