### PR TITLE
fix: thread-safety of Merger's internal LRU cache

### DIFF
--- a/lib/tailwind_merge.rb
+++ b/lib/tailwind_merge.rb
@@ -24,7 +24,7 @@ module TailwindMerge
       @config = merge_config(config)
       @config[:important_modifier] = @config[:important_modifier].to_s
       @class_utils = TailwindMerge::ClassGroupUtils.new(@config)
-      @cache = LruRedux::Cache.new(@config[:cache_size], @config[:ignore_empty_cache])
+      @cache = LruRedux::ThreadSafeCache.new(@config[:cache_size], @config[:ignore_empty_cache])
       @postfix_lookup_class_group_ids = build_postfix_lookup_class_group_ids(@config[:postfix_lookup_class_groups])
     end
 

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestThreadSafety < Minitest::Test
+  # A single Merger instance is commonly shared process-wide (as the README
+  # recommends), so its internal cache is hit by many threads at once. Unique
+  # keys force concurrent inserts and LRU evictions, repeated keys force the
+  # hit path's delete/re-insert. With a non-thread-safe cache this corrupts the
+  # cache Hash on GVL-less engines (JRuby/TruffleRuby): threads livelock inside
+  # the eviction loop (caught below by the join deadline) or results go wrong.
+  # Assertions happen after the join — anything slow inside the loop spaces out
+  # cache operations and hides the race.
+  def test_shared_merger_is_thread_safe
+    merger = TailwindMerge::Merger.new(config: { cache_size: 100 })
+
+    warm_inputs = Array.new(20) { |i| "px-#{i} py-#{i} px-8" }
+    expected = warm_inputs.map { |input| TailwindMerge::Merger.new.merge(input) }
+
+    mismatches = Queue.new
+    threads = Array.new(16) do |t|
+      Thread.new do # rubocop:disable ThreadSafety/NewThread
+        2000.times do |i|
+          merger.merge("m-#{t}-#{i} p-#{i}")
+          key = (t + i) % warm_inputs.size
+          result = merger.merge(warm_inputs[key])
+          mismatches << [warm_inputs[key], expected[key], result] if result != expected[key]
+        end
+      end
+    end
+
+    deadline = Time.now + 30
+    finished = threads.all? { |thread| thread.join([deadline - Time.now, 0].max) }
+
+    assert(finished, "threads still running after 30s — cache livelock")
+    assert_empty(Array.new(mismatches.size) { mismatches.pop })
+  end
+end


### PR DESCRIPTION
### TL;DR

`TailwindMerge::Merger` stores merge results in `LruRedux::Cache`, which is not thread-safe — [its own docs say so](https://github.com/cadenza-tech/sin_lru_redux#usage) — while the README here recommends sharing one `Merger` instance. On JRuby a shared merger **livelocks the whole process at 100% CPU**; on MRI it silently wastes CPU on duplicated merges. The fix is a one-line swap to `LruRedux::ThreadSafeCache`, the synchronized drop-in that ships in the same `sin_lru_redux` gem and is already loaded.

### How I found it

I was adding an optional tailwind_merge integration to my [clsx-ruby](https://github.com/svyatov/clsx-ruby) gem — it memoizes a single `TailwindMerge::Merger` process-wide, exactly like the README here suggests — and while auditing my own code for thread-safety I realized the shared merger underneath it mutates a plain, unsynchronized Hash from every thread.

### The problem

Every `merge` call funnels into the cache:

```ruby
# lib/tailwind_merge.rb
@cache = LruRedux::Cache.new(@config[:cache_size], @config[:ignore_empty_cache])
...
@cache.getset(normalized) { merge_class_list(normalized).freeze }
```

and `getset` is a compound, unsynchronized mutation of a plain Hash (`sin_lru_redux-2.5.2/lib/lru_redux/cache.rb`):

```ruby
def getset(key)
  key_found = true
  value = @data_lru.delete(key) { key_found = false }  # mutation 1
  if key_found
    @data_lru[key] = value                             # mutation 2 (LRU bump)
  else
    result = yield
    store_item(key, result)                            # delete + []= + evict_excess
    result
  end
end

def evict_excess
  @data_lru.shift while @data_lru.size > @max_size     # mutation loop
end
```

Sharing one `Merger` across threads is the documented usage (`@merger = TailwindMerge::Merger.new` in the README, typically memoized process-wide in Rails), so under Puma/Sidekiq every request thread runs these mutations concurrently on the same Hash.

### Impact

**JRuby (and any GVL-less engine):** concurrent unsynchronized mutation corrupts the Hash's internal state, after which `@data_lru.shift while @data_lru.size > @max_size` can never terminate — every thread that touches the cache gets stuck in that loop forever, pinning all cores. Not a crash you can rescue; the process just stops making progress. Reproduced 3 out of 3 runs with the PoC below:

```
HANG: 16/16 threads still running after 60s
(single-threaded this takes <5s; threads are spinning inside the corrupted cache Hash)
  stuck thread 1 backtrace (top 5):
    .../sin_lru_redux-2.5.2/lib/lru_redux/cache.rb:141:in 'shift'
    .../sin_lru_redux-2.5.2/lib/lru_redux/cache.rb:141:in 'evict_excess'
    .../sin_lru_redux-2.5.2/lib/lru_redux/cache.rb:161:in 'store_item'
    .../sin_lru_redux-2.5.2/lib/lru_redux/cache.rb:47:in 'getset'
    .../lib/tailwind_merge.rb:34:in 'merge'
```

With this PR, the same PoC completes cleanly in ~3s (3/3 runs).

**MRI:** the GVL keeps each individual Hash operation atomic, so no corruption and results stay correct. The cost is wasted work: when a thread is preempted inside the `yield`, other threads miss on the same key and recompute it (thundering herd), and racing hit-path delete/re-inserts can drop warm entries. With the PoC below (8 threads, 100 unique class strings, one shared merger), consistently across runs:

```
before: merge computations: 110  (10 inputs computed more than once)
after:  merge computations: 100  (exactly one per unique input)
```

### The fix

```diff
-      @cache = LruRedux::Cache.new(@config[:cache_size], @config[:ignore_empty_cache])
+      @cache = LruRedux::ThreadSafeCache.new(@config[:cache_size], @config[:ignore_empty_cache])
```

`ThreadSafeCache` is `Cache` with every method wrapped in a Monitor — same API, ships in the same gem, `require "lru_redux"` already loads it.

Trade-offs, stated honestly:

- Cache-hit cost goes from ~330–370ns to ~610–700ns per `merge` call (still >1.4M merges/sec single-threaded; an actual cache-miss merge costs tens of microseconds, so this is noise in any real workload). Benchmark script below.
- `getset` holds the monitor while the block computes, so concurrent *misses* serialize. That's what makes "compute once per key" possible, and for typical µs-scale merges it's irrelevant.

### Regression test

`test/test_thread_safety.rb`: 16 threads hammer one shared merger — unique keys force concurrent inserts/evictions, repeated keys force the hit-path delete/re-insert; a join deadline converts a livelock into a test failure, and results are verified against single-threaded output.

- JRuby without the fix: **fails 3/3** (`threads still running after 30s — cache livelock`)
- JRuby with the fix: passes
- MRI: passes before and after (the GVL masks the race) — on MRI the test's job is guarding future cache changes; it takes ~0.6s

### PoC scripts

Run against a checkout: `ruby -I lib poc_mri.rb` / `jruby -I lib poc_jruby.rb` (JRuby needs `gem install sin_lru_redux` first).

<details>
<summary><code>poc_mri.rb</code> — duplicated merge computations on MRI</summary>

```ruby
# PoC (MRI): TailwindMerge::Merger's internal cache (LruRedux::Cache) is not
# thread-safe, so a shared Merger duplicates work under concurrency.
#
# LruRedux::Cache#getset is a compound, unsynchronized operation:
#   delete(key) -> [miss] -> yield (compute merge) -> store
# When a thread is preempted inside the yield, other threads looking up the
# same key also miss and recompute it (thundering herd). On MRI the GVL keeps
# the Hash itself consistent, so the damage is wasted CPU. On engines without
# a GVL (JRuby/TruffleRuby) the same race corrupts the Hash itself — see
# poc_jruby.rb.

require "tailwind_merge"

# Non-invasive counter: how many times the real merge computation runs.
module MergeComputationCounter
  COUNT = Hash.new(0)
  LOCK = Mutex.new

  private def merge_class_list(class_list)
    LOCK.synchronize { COUNT[class_list] += 1 }
    super
  end
end
TailwindMerge::Merger.prepend(MergeComputationCounter)

THREADS = 8
UNIQUE_INPUTS = 100

# ~2000 classes each — a large template class string (~13ms to merge), long
# enough for MRI's preemption timer to interrupt the computation.
inputs = Array.new(UNIQUE_INPUTS) do |k|
  Array.new(2000) { |i| ["px-#{i}", "mt-#{i}", "hover:bg-red-#{i}", "focus:ring-#{i}", "text-[#{i}px]"][i % 5] }.join(" ") + " key-#{k}"
end

merger = TailwindMerge::Merger.new

threads = Array.new(THREADS) do
  Thread.new { inputs.each { |input| merger.merge(input) } }
end
threads.each(&:join)

total = MergeComputationCounter::COUNT.values.sum
duplicated = MergeComputationCounter::COUNT.count { |_, v| v > 1 }

puts "#{THREADS} threads, #{UNIQUE_INPUTS} unique class strings, one shared Merger:"
puts "  merge computations: #{total} (thread-safe cache: exactly #{UNIQUE_INPUTS})"
puts "  inputs computed more than once: #{duplicated}"
```

</details>

<details>
<summary><code>poc_jruby.rb</code> — livelock on JRuby</summary>

```ruby
# PoC (JRuby / any GVL-less engine): sharing one TailwindMerge::Merger across
# threads crashes, hangs, or corrupts, because its internal LruRedux::Cache
# mutates a plain Hash with no synchronization.
#
# 16 threads hammer one shared Merger (the usage the README recommends):
# unique keys force concurrent inserts + LRU evictions, repeated keys force the
# hit path's delete/re-insert. Possible outcomes on JRuby:
#   - RuntimeError/ConcurrencyError from Hash internals
#   - threads spinning forever inside the corrupted Hash (the classic
#     unsynchronized-HashMap infinite loop) — detected by the watchdog below
#   - wrong results returned from the cache
#
# For scale: single-threaded, this workload finishes in well under 5 seconds.

require "tailwind_merge"

THREADS = 16
ITERATIONS = 2_000
WATCHDOG_SECONDS = 60

merger = TailwindMerge::Merger.new(config: { cache_size: 100 })

warm_keys = Array.new(20) { |i| "px-#{i} py-#{i} px-8" }
expected = warm_keys.map { |k| TailwindMerge::Merger.new.merge(k) }

errors = Queue.new
mismatches = Queue.new

threads = Array.new(THREADS) do |t|
  Thread.new do
    ITERATIONS.times do |i|
      # unique key -> concurrent insert + eviction churn
      merger.merge("m-#{t}-#{i} p-#{i}")
      # warm key -> concurrent hit-path delete/re-insert
      k = (t + i) % warm_keys.size
      result = merger.merge(warm_keys[k])
      mismatches << [warm_keys[k], expected[k], result] if result != expected[k]
    end
  rescue => e
    errors << e
  end
end

deadline = Time.now + WATCHDOG_SECONDS
threads.each { |t| t.join([deadline - Time.now, 0].max) }
stuck = threads.select(&:alive?)

failed = false

unless stuck.empty?
  failed = true
  puts "HANG: #{stuck.size}/#{THREADS} threads still running after #{WATCHDOG_SECONDS}s"
  puts "(single-threaded this takes <5s; threads are spinning inside the corrupted cache Hash)"
  stuck.first(3).each_with_index do |t, i|
    puts "  stuck thread #{i + 1} backtrace (top 5):"
    (t.backtrace || []).first(5).each { |line| puts "    #{line}" }
  end
end

until errors.empty?
  failed = true
  e = errors.pop
  puts "CRASH: #{e.class}: #{e.message}"
end

unless mismatches.empty?
  failed = true
  key, want, got = mismatches.pop
  puts "WRONG RESULTS: #{mismatches.size + 1} bad merge results, e.g. #{key.inspect} => #{got.inspect} (expected #{want.inspect})"
end

puts "No errors — run again, the race is probabilistic" unless failed

# Force-kill the process: threads spinning in the corrupted Hash never stop,
# and on JRuby they even survive exit!/System.exit — halt the JVM directly.
status = failed ? 1 : 0
java.lang.Runtime.runtime.halt(status) if RUBY_ENGINE == "jruby"
exit!(status)
```

</details>

<details>
<summary><code>bench.rb</code> — cache-hit overhead of the fix</summary>

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "sin_lru_redux"
  gem "benchmark-ips"
end

require "tailwind_merge"
require "benchmark/ips"

INPUT = "flex items-center justify-between px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2"

plain = TailwindMerge::Merger.new
plain.instance_variable_set(:@cache, LruRedux::Cache.new(500, false))
safe = TailwindMerge::Merger.new # ThreadSafeCache after the fix

plain.merge(INPUT)
safe.merge(INPUT)

Benchmark.ips do |x|
  x.report("merge, cache hit (LruRedux::Cache)") { plain.merge(INPUT) }
  x.report("merge, cache hit (ThreadSafeCache)") { safe.merge(INPUT) }
  x.compare!
end
```

```
merge, cache hit (LruRedux::Cache)      3.011M (±52.7%) i/s  (332.07 ns/i)
merge, cache hit (ThreadSafeCache)      1.422M (±40.3%) i/s  (703.27 ns/i)
```

</details>

### Notes

- Tested on macOS arm64: CRuby 4.0.5 and JRuby 10.1.0.0 (OpenJDK 21), `sin_lru_redux` 2.5.2. Full suite + RuboCop green on this branch.
- The JS original can't have this bug — JS is single-threaded — so there's nothing to port; this is Ruby-specific.
- Related but out of scope: `Config::DEFAULTS.freeze` is shallow, so the nested theme/class_groups arrays are process-global mutable objects shared by reference across all `Merger` instances (that sharing is what made the #77 leak possible). Nothing mutates them at runtime today, so it's latent, not broken — but deep-freezing them would lock that in. Happy to send a follow-up PR if you want it.
