### PR TITLE
perf: reduce allocations in merge hot path (~35% faster, ~56% fewer allocations)

### DIFF
--- a/benchmark/benchmark.rb
+++ b/benchmark/benchmark.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Benchmark for the cache-miss merge path.
+#
+# Usage: ruby benchmark/benchmark.rb
+#
+# Measures `merge_class_list` directly: `merge` memoizes whole input strings
+# in an LRU cache, so benchmarking it with a fixed corpus would mostly
+# measure a Hash lookup. The uncached path is what runs for every
+# first-seen class string in a real app.
+
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "benchmark-ips"
+  gem "memory_profiler"
+  gem "sin_lru_redux"
+end
+
+require_relative "../lib/tailwind_merge"
+
+CORPUS = [
+  # simple conflicts
+  "px-2 px-4",
+  "text-sm text-lg font-bold",
+  "block inline flex",
+  # modifiers
+  "hover:focus:!bg-red-500 hover:focus:!bg-blue-600",
+  "md:hover:underline md:hover:no-underline",
+  "dark:sm:hover:bg-gray-800 dark:sm:hover:bg-gray-900",
+  # postfix modifiers
+  "bg-red-500/50 bg-red-500/75",
+  "text-white/90 leading-7",
+  # arbitrary values / properties / variables
+  "p-[2px] p-[4px]",
+  "[mask-type:luminance] [mask-type:alpha]",
+  "bg-(--brand-color) bg-red-500",
+  "content-['hello'] content-['world']",
+  # non-tailwind classes mixed in
+  "my-custom-class px-2 another-class px-4",
+  # long realistic string (shadcn-style button + overrides)
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md " \
+    "text-sm font-medium transition-colors focus-visible:outline-none " \
+    "focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none " \
+    "disabled:opacity-50 bg-primary text-primary-foreground shadow " \
+    "hover:bg-primary/90 h-9 px-4 py-2 rounded-lg px-6 text-base w-full",
+].freeze
+
+merger = TailwindMerge::Merger.new
+
+# sanity check: outputs must be non-empty
+CORPUS.each do |s|
+  result = merger.send(:merge_class_list, s)
+  raise "unexpected empty result for #{s.inspect}" if result.empty?
+end
+
+puts "ruby #{RUBY_VERSION} (#{RUBY_ENGINE}), tailwind_merge #{TailwindMerge::VERSION}"
+puts
+
+Benchmark.ips do |x|
+  x.report("merge_class_list (corpus of #{CORPUS.size})") do
+    CORPUS.each { |s| merger.send(:merge_class_list, s) }
+  end
+  x.report("merge_class_list (long string)") do
+    merger.send(:merge_class_list, CORPUS.last)
+  end
+end
+
+puts
+report = MemoryProfiler.report do
+  CORPUS.each { |s| merger.send(:merge_class_list, s) }
+end
+puts "allocations for one corpus pass: " \
+  "#{report.total_allocated} objects, #{report.total_allocated_memsize} bytes"

--- a/lib/tailwind_merge.rb
+++ b/lib/tailwind_merge.rb
@@ -18,14 +18,13 @@ module TailwindMerge
     include ParseClassName
     include SortModifiers
 
-    SPLIT_CLASSES_REGEX = /\s+/
-
     def initialize(config: {})
       @config = merge_config(config)
       @config[:important_modifier] = @config[:important_modifier].to_s
       @class_utils = TailwindMerge::ClassGroupUtils.new(@config)
       @cache = LruRedux::Cache.new(@config[:cache_size], @config[:ignore_empty_cache])
       @postfix_lookup_class_group_ids = build_postfix_lookup_class_group_ids(@config[:postfix_lookup_class_groups])
+      @order_sensitive_modifiers = Set.new(@config[:order_sensitive_modifiers]).freeze
     end
 
     def merge(classes)
@@ -42,14 +41,14 @@ module TailwindMerge
       # @example 'float'
       # @example 'hover:focus:bg-color'
       # @example 'md:!pr'
-      trimmed = class_list.strip
-      return "" if trimmed.empty?
+      class_names = class_list.split
+      return "" if class_names.empty?
 
       class_groups_in_conflict = Set.new
 
       merged_classes = []
 
-      trimmed.split(SPLIT_CLASSES_REGEX).reverse_each do |original_class_name|
+      class_names.reverse_each do |original_class_name|
         result = parse_class_name(original_class_name, prefix: @config[:prefix])
         is_external = result.is_external
         modifiers = result.modifiers
@@ -65,7 +64,8 @@ module TailwindMerge
         has_postfix_modifier = maybe_postfix_modifier_position ? true : false
 
         if has_postfix_modifier
-          base_class_name_without_postfix = base_class_name[0...maybe_postfix_modifier_position]
+          # maybe_postfix_modifier_position is a byte offset (see ParseClassName)
+          base_class_name_without_postfix = base_class_name.byteslice(0, maybe_postfix_modifier_position)
           class_group_id = @class_utils.class_group_id(base_class_name_without_postfix)
 
           if class_group_id && @postfix_lookup_class_group_ids[class_group_id]
@@ -97,10 +97,13 @@ module TailwindMerge
           has_postfix_modifier = false
         end
 
-        variant_modifier = sort_modifiers(modifiers, @config[:order_sensitive_modifiers]).join(":")
+        variant_modifier = sort_modifiers(modifiers, @order_sensitive_modifiers).join(":")
 
         modifier_id = has_important_modifier ? "#{variant_modifier}#{IMPORTANT_MODIFIER}" : variant_modifier
-        class_id = "#{modifier_id}#{class_group_id}"
+        has_modifier_id = !modifier_id.empty?
+        # `to_s` matches the previous interpolation behavior: group ids may be
+        # Symbols (custom configs) or Strings (defaults, where to_s is free)
+        class_id = has_modifier_id ? "#{modifier_id}#{class_group_id}" : class_group_id.to_s
 
         # Tailwind class omitted due to conflict
         next if class_groups_in_conflict.include?(class_id)
@@ -108,14 +111,14 @@ module TailwindMerge
         class_groups_in_conflict << class_id
 
         @class_utils.get_conflicting_class_group_ids(class_group_id, has_postfix_modifier).each do |conflicting_id|
-          class_groups_in_conflict << "#{modifier_id}#{conflicting_id}"
+          class_groups_in_conflict << (has_modifier_id ? "#{modifier_id}#{conflicting_id}" : conflicting_id.to_s)
         end
 
         # Tailwind class not in conflict
         merged_classes << original_class_name
       end
 
-      merged_classes.reverse.join(" ")
+      merged_classes.reverse!.join(" ")
     end
 
     private def build_postfix_lookup_class_group_ids(class_group_ids)

--- a/lib/tailwind_merge/class_group_utils.rb
+++ b/lib/tailwind_merge/class_group_utils.rb
@@ -23,25 +23,26 @@ module TailwindMerge
       get_group_recursive(class_parts, @class_map) || get_group_id_for_arbitrary_property(class_name)
     end
 
-    def get_group_recursive(class_parts, class_part_object)
-      return class_part_object[:class_group_id] if class_parts.empty?
+    def get_group_recursive(class_parts, class_part_object, index = 0)
+      return class_part_object[:class_group_id] if index == class_parts.length
 
-      current_class_part = class_parts.first
+      current_class_part = class_parts[index]
 
       next_class_part_object = class_part_object[:next_part][current_class_part]
 
       if next_class_part_object
-        class_group_from_next_class_part = get_group_recursive(class_parts.drop(1), next_class_part_object)
+        class_group_from_next_class_part = get_group_recursive(class_parts, next_class_part_object, index + 1)
         return class_group_from_next_class_part if class_group_from_next_class_part
       end
 
       return if class_part_object[:validators].empty?
 
-      class_rest = class_parts.join(CLASS_PART_SEPARATOR)
+      class_rest = index.zero? ? class_parts.join(CLASS_PART_SEPARATOR) : class_parts[index..].join(CLASS_PART_SEPARATOR)
 
+      # Theme procs are expanded at trie-build time (see process_classes_recursively),
+      # so validators here are always plain value validators.
       result = class_part_object[:validators].find do |v|
-        validator = v[:validator]
-        from_theme?(validator) ? validator.call(@config) : validator.call(class_rest)
+        v[:validator].call(class_rest)
       end
 
       result&.fetch(:class_group_id, nil)

--- a/lib/tailwind_merge/parse_class_name.rb
+++ b/lib/tailwind_merge/parse_class_name.rb
@@ -9,6 +9,13 @@ module TailwindMerge
     MODIFIER_SEPARATOR = ":"
     MODIFIER_SEPARATOR_LENGTH = MODIFIER_SEPARATOR.length
 
+    MODIFIER_SEPARATOR_BYTE = MODIFIER_SEPARATOR.ord
+    POSTFIX_SEPARATOR_BYTE = "/".ord
+    OPEN_BRACKET_BYTE = "[".ord
+    CLOSE_BRACKET_BYTE = "]".ord
+    OPEN_PAREN_BYTE = "(".ord
+    CLOSE_PAREN_BYTE = ")".ord
+
     ##
     # Parse class name into parts.
     #
@@ -37,25 +44,39 @@ module TailwindMerge
       modifier_start = 0
       postfix_modifier_position = nil
 
-      class_name.each_char.with_index do |char, index|
+      # Byte-wise scan: all separators are ASCII, so byte positions are safe
+      # for multibyte class names (UTF-8 continuation bytes never match ASCII).
+      # Positions produced here (including maybe_postfix_modifier_position)
+      # are byte offsets and must be consumed with String#byteslice.
+      index = 0
+      size = class_name.bytesize
+      while index < size
+        byte = class_name.getbyte(index)
+
         if bracket_depth.zero? && paren_depth.zero?
-          if char == MODIFIER_SEPARATOR
-            modifiers << class_name[modifier_start...index]
+          if byte == MODIFIER_SEPARATOR_BYTE
+            modifiers << class_name.byteslice(modifier_start, index - modifier_start)
             modifier_start = index + MODIFIER_SEPARATOR_LENGTH
+            index += 1
             next
-          elsif char == "/"
+          elsif byte == POSTFIX_SEPARATOR_BYTE
             postfix_modifier_position = index
+            index += 1
             next
           end
         end
 
-        bracket_depth += 1 if char == "["
-        bracket_depth -= 1 if char == "]"
-        paren_depth += 1 if char == "("
-        paren_depth -= 1 if char == ")"
+        case byte
+        when OPEN_BRACKET_BYTE then bracket_depth += 1
+        when CLOSE_BRACKET_BYTE then bracket_depth -= 1
+        when OPEN_PAREN_BYTE then paren_depth += 1
+        when CLOSE_PAREN_BYTE then paren_depth -= 1
+        end
+
+        index += 1
       end
 
-      base_class_name_with_important_modifier = modifiers.empty? ? class_name : class_name[modifier_start..]
+      base_class_name_with_important_modifier = modifiers.empty? ? class_name : class_name.byteslice(modifier_start, size - modifier_start)
 
       base_class_name, has_important_modifier = strip_important_modifier(base_class_name_with_important_modifier)
 

--- a/lib/tailwind_merge/validators.rb
+++ b/lib/tailwind_merge/validators.rb
@@ -97,7 +97,7 @@ module TailwindMerge
     }
 
     IS_ARBITRARY_VALUE = ->(value) {
-      ARBITRARY_VALUE_REGEX.match(value)
+      ARBITRARY_VALUE_REGEX.match?(value)
     }
 
     IS_ARBITRARY_LENGTH = ->(value) {
@@ -129,7 +129,7 @@ module TailwindMerge
     }
 
     IS_ARBITRARY_VARIABLE = ->(value) {
-      ARBITRARY_VARIABLE_REGEX.match(value)
+      ARBITRARY_VARIABLE_REGEX.match?(value)
     }
 
     IS_ARBITRARY_VARIABLE_LENGTH = ->(value) {


### PR DESCRIPTION
Hi! 👋 While profiling `tailwind_merge` I found a few easy allocation wins in the cache-miss path of `Merger#merge`. All changes are behavior-preserving (full test suite passes, no API changes), and the PR ships a benchmark script so the numbers are reproducible.

## Results

Ruby 4.0.5 (arm64-darwin), `ruby benchmark/benchmark.rb`, measuring `merge_class_list` (the uncached path — `merge` itself memoizes whole strings in the LRU cache, so it would mostly measure a Hash lookup):

| Metric | main | this PR | Δ |
|---|---|---|---|
| Mixed corpus of 14 strings (i/s) | 3,270 | 4,467 | **+37%** |
| Long shadcn-style string (i/s) | 7,840 | 10,605 | **+35%** |
| Objects allocated per corpus pass | 1,813 | 801 | **−56%** |
| Bytes allocated per corpus pass | 114,512 | 47,688 | **−58%** |

Reproduce with `ruby benchmark/benchmark.rb` on both refs (it uses `bundler/inline`, no Gemfile changes needed).

## What changed and why

1. **Index-based trie walk** (`class_group_utils.rb`) — `get_group_recursive` called `class_parts.drop(1)` at every recursion level, copying the tail array each time (O(k²) allocations per lookup, and a lookup can happen up to 4× per token). It now passes an index down instead. This was the single biggest win.
2. **Dead `from_theme?` check removed from lookup** (`class_group_utils.rb`) — theme procs are expanded at trie-build time in `process_classes_recursively`, so validators stored in the trie are never theme procs; the per-validator `object_id` + Set lookup on every query was pure overhead.
3. **Byte-wise scan in `parse_class_name`** — `each_char.with_index` allocates a String per character plus an Enumerator per token. Replaced with a `while`/`getbyte` loop. All separators (`:`, `/`, `[]`, `()`) are ASCII, so byte positions are safe for multibyte class names (UTF-8 continuation bytes can never equal ASCII bytes); slicing consistently uses `byteslice`.
4. **`order_sensitive_modifiers` as a Set** — `sort_modifiers` did `Array#include?` (linear scan of 12 elements) per modifier; the Set is built once in `Merger#initialize`.
5. **`merge_class_list` micro-fixes** — bare `String#split` (strips + splits on whitespace in C, replacing `strip` + `/\s+/`), skip `modifier_id` string interpolation in the common zero-modifier case, and `reverse!` instead of `reverse`.
6. **`match?` instead of `match`** for the two truthiness-only validator lambdas (`IS_ARBITRARY_VALUE`, `IS_ARBITRARY_VARIABLE`) — avoids MatchData allocation.

## Verification

- `bundle exec rake test` — 84 runs, 0 failures (includes the unicode/malicious-input/cache-tampering suites)
- `bundle exec rake rubocop` — clean
- Spot-checked unicode arbitrary values, prefixed configs, postfix modifiers, and array inputs

Happy to split this up or adjust anything — thanks for the gem! 🙏