### PR TITLE
chore: deep-freeze Config::DEFAULTS (follow-up to #79)

### DIFF
--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -6,6 +6,19 @@ module TailwindMerge
   module Config
     include Validators
 
+    class << self
+      # Recursively freezes nested Hash/Array structures so shared config
+      # constants can't be mutated in place. Keys are strings/symbols and are
+      # already immutable, so only values need walking.
+      private def deep_freeze(object)
+        case object
+        when Hash then object.each_value { |value| deep_freeze(value) }
+        when Array then object.each { |value| deep_freeze(value) }
+        end
+        object.freeze
+      end
+    end
+
     THEME_KEYS = [
       "color",
       "font",
@@ -2441,7 +2454,8 @@ module TailwindMerge
         "placeholder",
         "selection",
       ],
-    }.freeze
+    }
+    deep_freeze(DEFAULTS)
 
     def merge_config(incoming_config)
       extended_config = TailwindMerge::Config::DEFAULTS.dup

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -14,6 +14,23 @@ class TestConfig < Minitest::Test
     refute(config[:class_groups]["overflow"].first[:nonexistent])
   end
 
+  def test_defaults_is_deeply_frozen
+    unfrozen = []
+    walk = lambda do |object, path|
+      case object
+      when Hash
+        unfrozen << path unless object.frozen?
+        object.each { |key, value| walk.call(value, "#{path}[#{key.inspect}]") }
+      when Array
+        unfrozen << path unless object.frozen?
+        object.each_with_index { |value, index| walk.call(value, "#{path}[#{index}]") }
+      end
+    end
+    walk.call(TailwindMerge::Config::DEFAULTS, "DEFAULTS")
+
+    assert_empty(unfrozen, "Unfrozen nested structures: #{unfrozen.first(10).join(", ")}")
+  end
+
   def test_custom_theme_does_not_mutate_default_config
     default_spacing = TailwindMerge::Config::DEFAULTS[:theme]["spacing"].dup
 


### PR DESCRIPTION
### TL;DR

This is the follow-up you were happy to take in #79. `Config::DEFAULTS` is only shallow-frozen, so the nested `:theme` and `:class_groups` arrays inside it are still mutable objects shared by reference across every `Merger`. This deep-freezes the whole structure, so any accidental in-place write raises `FrozenError` at the exact line instead of silently corrupting process-global state.

### Why

You already fixed the actual bug in #77: `merge_config` was extending a validator array that still pointed into `DEFAULTS`, which leaked memory and slowed validation on every `Merger.new`. That patched the one mutation path we knew about.

The underlying shape is still a footgun, though. `DEFAULTS.freeze` only freezes the top-level hash; everything nested stays writable and shared. So "nobody mutates the defaults" is enforced by convention rather than by the runtime, and one stray `<<` or `[]=` anywhere in the code (or in a future change) silently corrupts state for every merger in the process, exactly the way #77 did.

To be clear, this isn't a bug fix. Nothing is broken today. It's a guardrail that turns that whole class of silent global-corruption bugs into a loud `FrozenError` pointing right at the offending write.

### The change

A small recursive `deep_freeze` that walks the nested hashes and arrays once at load time, replacing the single shallow `.freeze`:

```ruby
class << self
  private def deep_freeze(object)
    case object
    when Hash then object.each_value { |value| deep_freeze(value) }
    when Array then object.each { |value| deep_freeze(value) }
    end
    object.freeze
  end
end
# ...
}
deep_freeze(DEFAULTS)
```

It runs exactly once at `require` time, not per `Merger.new` and not on the merge hot path, so there's no runtime cost. Freezing the theme `Proc`s is a no-op and keeps their `object_id`, so the `from_theme?` identity check is unaffected.

### Why it's safe

Every existing write path already operates on a fresh or duped structure, so nothing starts raising:

- `merge_config` dups the top-level hash, dups `DEFAULTS[:theme]`, and dups each specific theme array before `<<`. `dup` on a frozen object returns an unfrozen copy, so those writes land on fresh arrays.
- `initialize` reassigns `important_modifier` on the already-duped `@config`, never on `DEFAULTS`.
- The trie build only reads `class_groups` and `theme`; all its writes go into a freshly-built `class_map`.

### One behavior change worth noting

If anyone out there reaches into `TailwindMerge::Config::DEFAULTS` and mutates it in place, they'll now get a `FrozenError`. Unlikely, and arguably the right thing to break, but I'd rather flag it than hide it.

### Tests

Added `test_defaults_is_deeply_frozen`, which walks the entire structure and asserts every nested hash and array is frozen, so a forgotten node at any depth fails the test rather than only the top level. Full suite is green on CRuby and RuboCop is clean.
