### PR TITLE
perf(parse): skip empty modifiers allocation on the no-modifier path

### DIFF
--- a/lib/tailwind_merge/parse_class_name.rb
+++ b/lib/tailwind_merge/parse_class_name.rb
@@ -6,6 +6,7 @@ module TailwindMerge
 
   module ParseClassName
     IMPORTANT_MODIFIER = "!"
+    EMPTY_MODIFIERS = [].freeze
     MODIFIER_SEPARATOR = ":"
     MODIFIER_SEPARATOR_LENGTH = MODIFIER_SEPARATOR.length
 
@@ -29,7 +30,7 @@ module TailwindMerge
         else
           return TailwindClass.new(
             is_external: true,
-            modifiers: [],
+            modifiers: EMPTY_MODIFIERS,
             has_important_modifier: false,
             base_class_name: class_name,
             maybe_postfix_modifier_position: nil,
@@ -37,7 +38,9 @@ module TailwindMerge
         end
       end
 
-      modifiers = []
+      # Stays nil until the first modifier separator, so the common no-modifier
+      # class (`px-2`, `block`) never allocates an array.
+      modifiers = nil
 
       bracket_depth = 0
       paren_depth = 0
@@ -55,7 +58,7 @@ module TailwindMerge
 
         if bracket_depth.zero? && paren_depth.zero?
           if byte == MODIFIER_SEPARATOR_BYTE
-            modifiers << class_name.byteslice(modifier_start, index - modifier_start)
+            (modifiers ||= []) << class_name.byteslice(modifier_start, index - modifier_start)
             modifier_start = index + MODIFIER_SEPARATOR_LENGTH
             index += 1
             next
@@ -76,7 +79,7 @@ module TailwindMerge
         index += 1
       end
 
-      base_class_name_with_important_modifier = modifiers.empty? ? class_name : class_name.byteslice(modifier_start, size - modifier_start)
+      base_class_name_with_important_modifier = modifiers ? class_name.byteslice(modifier_start, size - modifier_start) : class_name
 
       base_class_name, has_important_modifier = strip_important_modifier(base_class_name_with_important_modifier)
 
@@ -86,7 +89,7 @@ module TailwindMerge
 
       TailwindClass.new(
         is_external: false,
-        modifiers:,
+        modifiers: modifiers || EMPTY_MODIFIERS,
         has_important_modifier:,
         base_class_name: base_class_name,
         maybe_postfix_modifier_position:,


### PR DESCRIPTION
## What

`parse_class_name` allocated an empty `modifiers` array for every class it parsed, including the common cases that have no modifiers at all (`px-2`, `block`, `flex`) and every non-Tailwind class when a custom `prefix` is configured.

This keeps `modifiers` as `nil` until the first modifier separator is seen and falls back to a shared frozen `EMPTY_MODIFIERS` constant otherwise, so the no-modifier path never allocates.

Both no-modifier exits are covered: the main parse path and the `is_external` early-return (which previously allocated an array the merge loop never even reads for external classes).

## Impact

Deterministic allocation drop on the cache-miss path, measured over the benchmark corpus:

- 801 → 758 objects per corpus pass (−5.4%)
- 47688 → 45968 bytes

Throughput remains unchanged: the profile indicates that the remaining `merge_class_list` cost is due to inherent parsing and trie-walk work, rather than GC pressure, so this is a memory/GC-pressure win rather than a wall-clock one. It follows the same allocation-focused discipline as #80.

## Safety

`sort_modifiers` returns the modifiers array unchanged for size ≤ 1 and never mutates in place, so handing back a shared frozen array is safe. Full suite green (`86 runs, 542 assertions, 0 failures`), RuboCop clean.
