### PR TITLE
fix(config): classify shadow-inner into the shadow class group

### DIFF
--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -1445,6 +1445,8 @@ module TailwindMerge
             "shadow" => [
               # Deprecated since Tailwind CSS v4.0.0
               "",
+              # Deprecated since Tailwind CSS v4.0.0
+              "inner",
               "none",
               THEME_SHADOW,
               IS_ARBITRARY_VARIABLE_SHADOW,

--- a/test/test_tailwind_css_versions.rb
+++ b/test/test_tailwind_css_versions.rb
@@ -65,6 +65,12 @@ class TestTailwindCSSVersions < Minitest::Test
 
     assert_equal("via-(--mobile-header-gradient)", @merger.merge("via-red-500 via-(--mobile-header-gradient)"))
     assert_equal("via-red-500 via-(length:--mobile-header-gradient)", @merger.merge("via-red-500 via-(length:--mobile-header-gradient)"))
+
+    # shadow-inner is deprecated in v4 but still sets --tw-shadow, so it conflicts
+    # with other shadow utilities and not with shadow color utilities.
+    assert_equal("shadow-lg", @merger.merge("shadow-inner shadow-lg"))
+    assert_equal("shadow-inner", @merger.merge("shadow-lg shadow-inner"))
+    assert_equal("shadow-initial shadow-inner", @merger.merge("shadow-initial shadow-inner"))
   end
 
   def test_tailwind_4_1_features


### PR DESCRIPTION
Ports the fix from upstream [tailwind-merge#703](https://github.com/dcastil/tailwind-merge/pull/703) into the Ruby port.

## Problem

`shadow-inner` is a deprecated Tailwind v3 utility still shipped in v4 via the `--shadow-inner` theme variable. Its compiled CSS sets `--tw-shadow` — the same custom property as `shadow-lg` and every other shadow utility — so it **must** merge with other shadow utilities and must **not** merge with shadow-color utilities.

The `shadow` class group only matched the empty string, `none`, the t-shirt-size theme scale, and arbitrary values. So `shadow-inner` fell through to the permissive `shadow-color` group (the `IS_ANY` color scale matches anything), producing wrong merges:

```ruby
TailwindMerge::Merger.new.merge("shadow-inner shadow-lg")      # => "shadow-inner shadow-lg"   (should be "shadow-lg")
TailwindMerge::Merger.new.merge("shadow-lg shadow-inner")      # => "shadow-lg shadow-inner"   (should be "shadow-inner")
TailwindMerge::Merger.new.merge("shadow-initial shadow-inner") # => "shadow-inner"            (should be "shadow-initial shadow-inner")
```

## Fix

Add `inner` as a deprecated literal in the `shadow` class group (mirroring the v3-era classification and the upstream fix). The trie resolver (`get_group_recursive`) prefers literal matches over validators, so `shadow-inner` now resolves to the `shadow` group instead of `shadow-color`.

## Verification

- Added regression assertions to `test_tailwind_4_0_features` covering both merge directions and the non-conflict with `shadow-initial`. The new test fails on `main` and passes with this change.
- Full suite: `86 runs, 545 assertions, 0 failures`.
- `rubocop` clean on changed files.
