### PR TITLE
fix(config): add none option to max-h class group

### DIFF
--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -849,7 +849,7 @@ module TailwindMerge
         # Max-Height
         # @see https://tailwindcss.com/docs/max-height
         ##
-        "max-h" => [{ "max-h" => ["screen", "lh", *SCALE_SIZING.call] }],
+        "max-h" => [{ "max-h" => ["screen", "lh", "none", *SCALE_SIZING.call] }],
 
         ############
         # Typography

--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -696,22 +696,22 @@ module TailwindMerge
         # Margin X
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mx" => [{ "mx" => SCALE_MARGIN.call  }],
+        "mx" => [{ "mx" => SCALE_MARGIN.call }],
         ##
         # Margin Y
         # @see https://tailwindcss.com/docs/margin
         ##
-        "my" => [{ "my" => SCALE_MARGIN.call  }],
+        "my" => [{ "my" => SCALE_MARGIN.call }],
         #
         # Margin Start
         # @see https://tailwindcss.com/docs/margin
         #
-        "ms" => [{ "ms" => SCALE_MARGIN.call  }],
+        "ms" => [{ "ms" => SCALE_MARGIN.call }],
         #
         # Margin End
         # @see https://tailwindcss.com/docs/margin
         #
-        "me" => [{ "me" => SCALE_MARGIN.call  }],
+        "me" => [{ "me" => SCALE_MARGIN.call }],
         #
         # Margin Block Start
         # @see https://tailwindcss.com/docs/margin
@@ -731,17 +731,17 @@ module TailwindMerge
         # Margin Right
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mr" => [{ "mr" => SCALE_MARGIN.call  }],
+        "mr" => [{ "mr" => SCALE_MARGIN.call }],
         ##
         # Margin Bottom
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mb" => [{ "mb" => SCALE_MARGIN.call  }],
+        "mb" => [{ "mb" => SCALE_MARGIN.call }],
         ##
         # Margin Left
         # @see https://tailwindcss.com/docs/margin
         ##
-        "ml" => [{ "ml" => SCALE_MARGIN.call  }],
+        "ml" => [{ "ml" => SCALE_MARGIN.call }],
         ##
         # Space Between X
         # @see https://tailwindcss.com/docs/margin#adding-space-between-children

--- a/test/test_class_group_conflicts.rb
+++ b/test/test_class_group_conflicts.rb
@@ -18,6 +18,15 @@ class TestClassGroupConflicts < Minitest::Test
     assert_equal("gap-px basis-3", @merger.merge("gap-2 gap-px basis-px basis-3"))
   end
 
+  def test_merges_none_values_in_sizing_groups_correctly
+    assert_equal("max-w-none", @merger.merge("max-w-lg max-w-none"))
+    assert_equal("max-w-lg", @merger.merge("max-w-none max-w-lg"))
+    assert_equal("max-h-none", @merger.merge("max-h-96 max-h-none"))
+    assert_equal("max-h-96", @merger.merge("max-h-none max-h-96"))
+    assert_equal("max-h-none", @merger.merge("max-h-[300px] max-h-none"))
+    assert_equal("max-h-screen", @merger.merge("max-h-none max-h-screen"))
+  end
+
   def test_merges_classes_from_font_variant_numeric_section_correctly
     assert_equal("lining-nums tabular-nums diagonal-fractions", @merger.merge("lining-nums tabular-nums diagonal-fractions"))
     assert_equal("tabular-nums diagonal-fractions", @merger.merge("normal-nums tabular-nums diagonal-fractions"))


### PR DESCRIPTION
Adds the bare `none` literal to the `max-h` class group so `max-h-none` conflicts with other `max-h` classes (e.g. `merge("max-h-96 max-h-none")` → `max-h-none`). `min-h` already listed it.

Ports dcastil/tailwind-merge#704 (https://github.com/dcastil/tailwind-merge/pull/704).