### PR TITLE
fix(config): support container scale in inline sizing groups

### DIFF
--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -697,22 +697,22 @@ module TailwindMerge
         # Margin X
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mx" => [{ "mx" => SCALE_MARGIN.call  }],
+        "mx" => [{ "mx" => SCALE_MARGIN.call }],
         ##
         # Margin Y
         # @see https://tailwindcss.com/docs/margin
         ##
-        "my" => [{ "my" => SCALE_MARGIN.call  }],
+        "my" => [{ "my" => SCALE_MARGIN.call }],
         #
         # Margin Start
         # @see https://tailwindcss.com/docs/margin
         #
-        "ms" => [{ "ms" => SCALE_MARGIN.call  }],
+        "ms" => [{ "ms" => SCALE_MARGIN.call }],
         #
         # Margin End
         # @see https://tailwindcss.com/docs/margin
         #
-        "me" => [{ "me" => SCALE_MARGIN.call  }],
+        "me" => [{ "me" => SCALE_MARGIN.call }],
         #
         # Margin Block Start
         # @see https://tailwindcss.com/docs/margin
@@ -732,17 +732,17 @@ module TailwindMerge
         # Margin Right
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mr" => [{ "mr" => SCALE_MARGIN.call  }],
+        "mr" => [{ "mr" => SCALE_MARGIN.call }],
         ##
         # Margin Bottom
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mb" => [{ "mb" => SCALE_MARGIN.call  }],
+        "mb" => [{ "mb" => SCALE_MARGIN.call }],
         ##
         # Margin Left
         # @see https://tailwindcss.com/docs/margin
         ##
-        "ml" => [{ "ml" => SCALE_MARGIN.call  }],
+        "ml" => [{ "ml" => SCALE_MARGIN.call }],
         ##
         # Space Between X
         # @see https://tailwindcss.com/docs/margin#adding-space-between-children

--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -117,6 +117,7 @@ module TailwindMerge
     }
     SCALE_SIZING_INLINE = -> {
       [
+        THEME_CONTAINER,
         IS_FRACTION,
         "screen",
         "full",

--- a/test/test_tailwind_css_versions.rb
+++ b/test/test_tailwind_css_versions.rb
@@ -164,6 +164,9 @@ class TestTailwindCSSVersions < Minitest::Test
     assert_equal("max-inline-none", @merger.merge("max-inline-full max-inline-none"))
     assert_equal("min-block-auto", @merger.merge("min-block-full min-block-auto"))
     assert_equal("max-block-none", @merger.merge("max-block-full max-block-none"))
+    assert_equal("inline-3xl", @merger.merge("inline-2xl inline-3xl"))
+    assert_equal("min-inline-1/2", @merger.merge("min-inline-xs min-inline-1/2"))
+    assert_equal("max-inline-xl", @merger.merge("max-inline-svw max-inline-xl"))
 
     # Font feature settings
     assert_equal("font-features-[\"tnum\"]", @merger.merge("font-features-[\"smcp\"] font-features-[\"tnum\"]"))


### PR DESCRIPTION
Adds `THEME_CONTAINER` to `SCALE_SIZING_INLINE` so container-scale sizes like `inline-2xl`, `min-inline-xs`, and `max-inline-xl` merge correctly within their groups.

Ports dcastil/tailwind-merge#706 (https://github.com/dcastil/tailwind-merge/pull/706).