### PR TITLE
fix(config): make columns-auto conflict with other columns classes

### DIFF
--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -276,7 +276,7 @@ module TailwindMerge
         # Columns
         # @see https://tailwindcss.com/docs/columns
         ##
-        "columns" => [{ "columns" => [IS_TSHIRT_SIZE] }],
+        "columns" => [{ "columns" => [IS_NUMBER, "auto", IS_ARBITRARY_VALUE, IS_ARBITRARY_VARIABLE, THEME_CONTAINER] }],
         ##
         # Break After
         # @see https://tailwindcss.com/docs/break-after

--- a/lib/tailwind_merge/config.rb
+++ b/lib/tailwind_merge/config.rb
@@ -696,22 +696,22 @@ module TailwindMerge
         # Margin X
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mx" => [{ "mx" => SCALE_MARGIN.call  }],
+        "mx" => [{ "mx" => SCALE_MARGIN.call }],
         ##
         # Margin Y
         # @see https://tailwindcss.com/docs/margin
         ##
-        "my" => [{ "my" => SCALE_MARGIN.call  }],
+        "my" => [{ "my" => SCALE_MARGIN.call }],
         #
         # Margin Start
         # @see https://tailwindcss.com/docs/margin
         #
-        "ms" => [{ "ms" => SCALE_MARGIN.call  }],
+        "ms" => [{ "ms" => SCALE_MARGIN.call }],
         #
         # Margin End
         # @see https://tailwindcss.com/docs/margin
         #
-        "me" => [{ "me" => SCALE_MARGIN.call  }],
+        "me" => [{ "me" => SCALE_MARGIN.call }],
         #
         # Margin Block Start
         # @see https://tailwindcss.com/docs/margin
@@ -731,17 +731,17 @@ module TailwindMerge
         # Margin Right
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mr" => [{ "mr" => SCALE_MARGIN.call  }],
+        "mr" => [{ "mr" => SCALE_MARGIN.call }],
         ##
         # Margin Bottom
         # @see https://tailwindcss.com/docs/margin
         ##
-        "mb" => [{ "mb" => SCALE_MARGIN.call  }],
+        "mb" => [{ "mb" => SCALE_MARGIN.call }],
         ##
         # Margin Left
         # @see https://tailwindcss.com/docs/margin
         ##
-        "ml" => [{ "ml" => SCALE_MARGIN.call  }],
+        "ml" => [{ "ml" => SCALE_MARGIN.call }],
         ##
         # Space Between X
         # @see https://tailwindcss.com/docs/margin#adding-space-between-children

--- a/test/test_class_group_conflicts.rb
+++ b/test/test_class_group_conflicts.rb
@@ -15,6 +15,8 @@ class TestClassGroupConflicts < Minitest::Test
     assert_equal("hover:overflow-x-hidden overflow-x-scroll", @merger.merge("overflow-x-auto hover:overflow-x-hidden overflow-x-scroll"))
     assert_equal("hover:overflow-x-auto overflow-x-scroll", @merger.merge("overflow-x-auto hover:overflow-x-hidden hover:overflow-x-auto overflow-x-scroll"))
     assert_equal("col-span-full", @merger.merge("col-span-1 col-span-full"))
+    assert_equal("columns-auto", @merger.merge("columns-12 columns-auto"))
+    assert_equal("columns-2xl", @merger.merge("columns-auto columns-2xl"))
     assert_equal("gap-px basis-3", @merger.merge("gap-2 gap-px basis-px basis-3"))
   end
 


### PR DESCRIPTION
Adds `auto` to the `columns` class group and brings the group to upstream parity (`IS_NUMBER`, arbitrary values/variables, `THEME_CONTAINER`) — the port had drifted to only matching t-shirt sizes, so numeric classes like `columns-3` were never recognized.

Ports dcastil/tailwind-merge#707 (https://github.com/dcastil/tailwind-merge/pull/707).